### PR TITLE
Clone CHP landing page — static React layout and full styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,22 +1,360 @@
-.App {
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap');
+
+:root {
+  --text-primary: #1a1f4b;
+  --text-dark: #1b1842;
+  --muted: #6c6c81;
+  --background: #f4f1ee;
+  --surface: #ffffff;
+  --accent: #221f63;
+  --accent-soft: #453a86;
+  --gradient: linear-gradient(120deg, #9cc4f0, #f3a0b8);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  color: var(--text-primary);
+  background: var(--background);
+}
+
+.page {
+  min-height: 100vh;
+  background: var(--background);
+}
+
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 64px;
+  background: var(--surface);
+}
+
+.logo {
+  font-weight: 700;
+  letter-spacing: 2px;
+}
+
+.nav {
+  display: flex;
+  gap: 32px;
+}
+
+.nav a {
+  text-decoration: none;
+  color: var(--text-dark);
+  font-size: 14px;
+  letter-spacing: 0.5px;
+}
+
+.hero {
+  padding: 80px 24px 96px;
+  background: var(--gradient);
+  display: flex;
+  justify-content: center;
+}
+
+.hero-content {
+  max-width: 720px;
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
+.eyebrow {
+  font-weight: 600;
+  font-size: 18px;
+  margin-bottom: 12px;
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.hero h1 {
+  font-size: 30px;
+  margin-bottom: 16px;
+}
+
+.lead {
+  font-size: 14px;
+  color: var(--text-dark);
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+.hero-actions {
   display: flex;
-  flex-direction: column;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.button {
+  border: none;
+  padding: 10px 24px;
+  font-size: 13px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.button.primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.button.ghost {
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+}
+
+.split-section {
+  display: grid;
+  grid-template-columns: minmax(280px, 1.1fr) minmax(200px, 0.9fr);
+  gap: 32px;
+  padding: 64px;
+  background: var(--surface);
+}
+
+.split-section.light {
+  background: #efebe7;
+}
+
+.split-content h2 {
+  margin: 12px 0 16px;
+  font-size: 20px;
+}
+
+.split-content p {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.section-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: var(--text-dark);
+}
+
+.section-tag {
+  margin-top: 24px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 1px;
+}
+
+.split-panel {
+  background: var(--gradient);
+  border-radius: 0 16px 16px 0;
+  position: relative;
+}
+
+.split-panel::after {
+  content: '';
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+}
+
+.pill-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.benefits {
+  padding: 64px;
+  background: var(--surface);
+  text-align: center;
+}
+
+.benefits h2 {
+  margin-top: 12px;
+  margin-bottom: 24px;
+}
+
+.benefit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+  text-align: left;
+}
+
+.benefit-grid h3 {
+  margin-bottom: 8px;
+  font-size: 16px;
+}
+
+.benefit-grid p {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.info-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  padding: 24px 64px 64px;
+  background: var(--surface);
+}
+
+.card {
+  background: #f2f3f7;
+  padding: 24px;
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.card ul {
+  padding-left: 18px;
+}
+
+.card li {
+  margin-bottom: 10px;
+}
+
+.text-link {
+  margin-top: 16px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.trust {
+  padding: 48px 64px 24px;
+  background: var(--surface);
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+  padding: 32px 64px 64px;
+  background: var(--surface);
+}
+
+.feature {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.feature h3 {
+  margin-bottom: 8px;
+  color: var(--text-dark);
+}
+
+.partners {
+  height: 180px;
+  background: #e1ddd7;
+  display: flex;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
 }
 
-.App-link {
-  color: #09d3ac;
+.newsletter {
+  padding: 48px 64px;
+  background: var(--surface);
+}
+
+.newsletter h2 {
+  margin-bottom: 12px;
+}
+
+.newsletter p {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.contact {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(280px, 1.2fr);
+  gap: 32px;
+  padding: 48px 64px;
+  background: #6f6b80;
+  color: #fff;
+}
+
+.contact-info p,
+.contact-info li {
+  font-size: 13px;
+}
+
+.contact-info ul {
+  list-style: none;
+  padding: 0;
+}
+
+.contact-form {
+  background: #ffffff;
+  color: var(--text-dark);
+  padding: 24px;
+  border-radius: 6px;
+  display: grid;
+  gap: 12px;
+}
+
+.contact-form label {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 8px 10px;
+  border: 1px solid #d6d4db;
+  border-radius: 4px;
+  font-family: inherit;
+}
+
+@media (max-width: 900px) {
+  .site-header {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .split-section {
+    grid-template-columns: 1fr;
+  }
+
+  .split-panel {
+    min-height: 180px;
+    border-radius: 16px;
+  }
+
+  .contact {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .site-header,
+  .benefits,
+  .info-cards,
+  .trust,
+  .feature-grid,
+  .newsletter,
+  .contact,
+  .split-section {
+    padding: 32px 24px;
+  }
+
+  .hero {
+    padding: 64px 16px;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,36 +1,217 @@
-import React, { Component } from 'react';
-import logo from './logo.svg';
 import './App.css';
 
-class App extends Component {
+const App = () => {
+  return (
+    <div className="page">
+      <header className="site-header">
+        <div className="logo">CHP</div>
+        <nav className="nav">
+          <a href="#home">Home</a>
+          <a href="#offer">Offer</a>
+          <a href="#projects">Projects</a>
+          <a href="#contact">Contact</a>
+        </nav>
+      </header>
 
-    state = {};
-
-    componentDidMount() {
-        setInterval(this.hello, 250);
-    }
-
-    hello = () => {
-        fetch('/api/hello')
-            .then(response => response.text())
-            .then(message => {
-                this.setState({ message: message });
-            });
-    };
-
-    render() {
-        return (
-            <div className="App">
-                <header className="App-header">
-                    <img src={logo} className="App-logo" alt="logo" />
-                    <h1 className="App-title">zack{this.state.message}</h1>
-                </header>
-                <p className="App-intro">
-                    To get started, edit zack <code>src/App.js</code> and save to reload.
-                </p>
+      <main>
+        <section id="home" className="hero">
+          <div className="hero-content">
+            <p className="eyebrow">Built for Operations. Designed for Meetings</p>
+            <h1>An Event Management System for venues that already use a PMS.</h1>
+            <p className="lead">
+              CHP (Cyberdigma Hospitality Platform) helps venues manage meetings and
+              events in a more structured, predictable way - from availability and
+              pricing to bookings and day-to-day operations.
+            </p>
+            <div className="hero-actions">
+              <button className="button primary">Talk to us</button>
+              <button className="button ghost">Request a demo</button>
             </div>
-        );
-    }
-}
+          </div>
+        </section>
+
+        <section className="split-section light" id="offer">
+          <div className="split-content">
+            <p className="section-label">THE PROBLEM</p>
+            <h2>Meeting operations are still highly manual.</h2>
+            <p>
+              Emails, spreadsheets, disconnected tools, and slow internal processes
+              make it difficult for venues to stay in control, respond consistently,
+              and price meetings with confidence - especially when demand fluctuates.
+            </p>
+            <p className="section-tag">JUST CLEARER CONTROL OVER MEETING OPERATIONS</p>
+          </div>
+          <div className="split-panel"></div>
+        </section>
+
+        <section className="split-section" id="projects">
+          <div className="split-content">
+            <p className="section-label">THE SOLUTION</p>
+            <div className="pill-row">
+              <span>NO DISRUPTION</span>
+              <span>NO REPLACEMENT OF YOUR PMS</span>
+            </div>
+            <h2>Event management, built specifically for meeting venues</h2>
+            <p>
+              It works alongside your existing systems and gives your team one place
+              to manage availability, pricing logic, bookings, and operational workflows.
+            </p>
+            <p>
+              CHP is an Event Management System created for venues where meetings and
+              events are part of daily operations.
+            </p>
+          </div>
+          <div className="split-panel"></div>
+        </section>
+
+        <section className="benefits">
+          <p className="section-label">KEY BENEFITS</p>
+          <h2>Built to fit your operation</h2>
+          <div className="benefit-grid">
+            <div>
+              <h3>API-first, flexible</h3>
+              <p>
+                Designed to work with the systems you already use - without forcing
+                you into a new way of working.
+              </p>
+            </div>
+            <div>
+              <h3>Operational clarity</h3>
+              <p>
+                Reduce back-and-forth, speed up response times, and keep meeting-related
+                workflows structured and transparent.
+              </p>
+            </div>
+            <div>
+              <h3>Pricing &amp; yielding for meetings</h3>
+              <p>
+                Automatically adjust meeting prices based on occupancy, demand, or
+                availability, supporting smarter revenue decisions.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="info-cards">
+          <div className="card">
+            <p className="section-label">HOW IT WORKS</p>
+            <ul>
+              <li>A Meeting Booking Widget on your website</li>
+              <li>A central platform for availability, pricing logic, and operations</li>
+              <li>Works alongside your PMS and other hospitality systems</li>
+              <li>Designed as an add-on, not a replacement</li>
+            </ul>
+            <a className="text-link" href="#contact">
+              READ MORE ⟶
+            </a>
+          </div>
+          <div className="card">
+            <p className="section-label">WHO IS IT FOR</p>
+            <ul>
+              <li>Hotels and hospitality venues</li>
+              <li>Meeting and event centers</li>
+              <li>Coworking spaces</li>
+              <li>Teams responsible for operations, sales, and revenue</li>
+            </ul>
+            <p>If meetings are part of how your venue operates, CHP fits into your flow.</p>
+            <a className="text-link" href="#contact">
+              READ MORE ⟶
+            </a>
+          </div>
+        </section>
+
+        <section className="trust">
+          <p className="section-label">TRUST &amp; BACKGROUND</p>
+          <p>
+            CHP was shaped in live hospitality environments and continues to evolve
+            based on how venues actually work - focusing on operational reality rather
+            than generic software promises.
+          </p>
+          <p>Built from real venue operations and backed by Meetingselect.</p>
+        </section>
+
+        <section className="feature-grid">
+          <div className="feature">
+            <h3>Full Operations</h3>
+            <p>Complete control with role-based access.</p>
+          </div>
+          <div className="feature">
+            <h3>Invoice Control</h3>
+            <p>Tailor billing to your specific needs.</p>
+          </div>
+          <div className="feature">
+            <h3>Dynamic Pricing</h3>
+            <p>Maximize revenue with smart, real-time rate adjustments.</p>
+          </div>
+          <div className="feature">
+            <h3>Unified Venues</h3>
+            <p>Centralize all aspects of your event space operations.</p>
+          </div>
+          <div className="feature">
+            <h3>Instant Bookings</h3>
+            <p>Double your direct bookings with streamlined processes.</p>
+          </div>
+          <div className="feature">
+            <h3>API-First Platform</h3>
+            <p>Seamlessly integrate with existing systems for modern MICE bookings.</p>
+          </div>
+        </section>
+
+        <section className="partners">
+          <p className="section-label">PARTNERS</p>
+        </section>
+
+        <section className="newsletter">
+          <div>
+            <h2>Sign up for the CHP newsletter!</h2>
+            <p>
+              Stay inspired. Subscribe to our newsletter for fresh updates, special
+              offers, and a touch of colour in your inbox.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <footer id="contact" className="contact">
+        <div className="contact-info">
+          <h2>Contact</h2>
+          <p>
+            Have questions about modernizing your MICE bookings with CHP? Our team is
+            ready to assist with platform details, pricing, or integration support.
+            Reach out today!
+          </p>
+          <ul>
+            <li>+12345678901</li>
+            <li>contact@chp.com</li>
+            <li>Tech Park 5 Utrecht</li>
+          </ul>
+        </div>
+        <form className="contact-form">
+          <label>
+            First name
+            <input type="text" placeholder="First name" />
+          </label>
+          <label>
+            Last Name
+            <input type="text" placeholder="Last name" />
+          </label>
+          <label>
+            Phone number
+            <input type="tel" placeholder="Phone number" />
+          </label>
+          <label>
+            Your e-mail
+            <input type="email" placeholder="Your e-mail" />
+          </label>
+          <label>
+            Message content
+            <textarea rows="4" placeholder="Message"></textarea>
+          </label>
+          <button type="submit" className="button primary">Send</button>
+        </form>
+      </footer>
+    </div>
+  );
+};
 
 export default App;


### PR DESCRIPTION
### Motivation
- Recreate the CHP marketing landing page inside the existing React project so the app mirrors the referenced site structure and visual style.
- Replace the starter boilerplate that fetched `/api/hello` with a static, exportable React component for a self-contained frontend prototype.

### Description
- Replace `src/App.js` with a functional React component that implements the full page structure (header, hero, problem/solution split sections, benefits, info cards, trust, feature grid, newsletter, contact form). 
- Add `src/App.css` with typography, CSS variables, gradients, split layouts, responsive breakpoints, and component styling to match the cloned design. 
- Committed the changes to the repository and created a PR titled "Create landing page clone".

### Testing
- Ran `npm install` to fetch dependencies but the registry returned 403 errors and many packages could not be retrieved, so the install could not complete. (failed)
- Attempted `npm start` and `react-scripts` was not available locally due to the failed install, so the dev server did not start. (failed)
- Attempted `npm install react-scripts` but registry 403 responses prevented the dependency from being installed. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3d650828832a87297db44cebeba1)